### PR TITLE
Replace Path::Class with File::Spec

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,7 @@
             "File::Temp" : "0",
             "IO::File" : "0",
             "POSIX" : "0",
-            "Path::Class" : "0",
+            "File::Spec" : "0",
             "Time::HiRes" : "0"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,7 @@ requires 'IO::File';
 requires 'File::Temp';
 requires 'File::Copy';
 requires 'File::Sync';
-requires 'Path::Class';
+requires 'File::Spec';
 requires 'POSIX';
 
 on develop => sub {

--- a/lib/IO/File/AtomicChange.pm
+++ b/lib/IO/File/AtomicChange.pm
@@ -92,11 +92,11 @@ sub copy_modown_to_temp {
 sub backup {
     my($self) = @_;
 
-    require Path::Class;
+    require File::Spec;
     require POSIX;
     require Time::HiRes;
 
-    my $basename = Path::Class::file($self->_target_file)->basename;
+    my $basename = File::Spec->splitpath($self->_target_file);
 
     my $backup_file;
     my $n = 0;

--- a/t/20_backup.t
+++ b/t/20_backup.t
@@ -44,11 +44,11 @@ $testee = write_and_read([$target_file, "a", {backup_dir=>$backup_dir}], \@data)
 push @wrote, @data;
 @backup2 = list_backup($backup_dir, $basename);
 is(scalar(@backup2), 2, "do backup (2)");
-my %old_backup = map { $_->stringify => 1 } @backup;
-@backup2 = grep { ! $old_backup{ $_->stringify } } @backup2;
+my %old_backup = map { $_ => 1 } @backup;
+@backup2 = grep { ! $old_backup{ $_ } } @backup2;
 
 ###
 ###
 is($testee, join("",@wrote), "new data");
-$testee = $backup2[0]->slurp;
+$testee = slurp($backup2[0]);
 is($testee, $data_backuped, "backuped data");

--- a/t/30_stat.t
+++ b/t/30_stat.t
@@ -47,6 +47,6 @@ push @stat_old, stat_time($target_file);
 $testee = write_and_read([$target_file, "w", {backup_dir=>$backup_dir}], \@data);
 is($testee, join("",@data), "create truncate write");
 @backup = list_backup($backup_dir, $basename);
-@stat = stat_mode_owner($backup[0]->stringify);
-push @stat, stat_time($backup[0]->stringify);
+@stat = stat_mode_owner($backup[0]);
+push @stat, stat_time($backup[0]);
 is_deeply(\@stat, \@stat_old, "mtime preserved?");


### PR DESCRIPTION
Subject says it all. Funnily enough with all the `->stringify` and repeated `->basename` gone, I find the code is actually *more* readable. (It’s also more efficient… though that doesn’t matter in this code.)